### PR TITLE
fix(css): don't rewrite CSS urls starting with $

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1044,7 +1044,7 @@ async function rebaseUrls(
     return { file }
   }
   const rebased = await rewriteCssUrls(content, (url) => {
-    if (url.startsWith('/')) return url
+    if (url.startsWith('/') || url.startsWith('$')) return url
     // match alias, no need to rewrite
     for (const { find } of alias) {
       const matches =


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

URL might be a variable rather than a string.
When vite attempts to rewrite a variable it might produce bogus output as it doesn't know what value given variable holds.

Currently this can cause a build error like the one below:

```
Error: expected ")".
  ╷
9 │   @import url(../../node_modules/bootswatch/dist/darkly/$web-font-path);
  │               ^
  ╵
  node_modules/bootswatch/dist/darkly/_bootswatch.scss 9:15  @import
  src/Styles/DarkTheme.scss 75:9                             @import
  src/Styles/DarkThemeLoader.scss 2:11                       root stylesheet
error during build:
Error: expected ")".
```

See https://github.com/thomaspark/bootswatch/blob/52649a617b7f66f0e8bc8128926a5c195ea7a5b4/dist/darkly/_bootswatch.scss#L7-L10

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
